### PR TITLE
Upgrade script run from Admin store

### DIFF
--- a/shell/upgrade.php
+++ b/shell/upgrade.php
@@ -65,6 +65,12 @@ class Guidance_Shell_Upgrade extends Mage_Shell_Abstract
         $start = microtime(true);
 
         try {
+		    //make upgrade scripts be executed from Admin store, not from default with ID = 1
+		    Mage::app()->setUpdateMode(true);
+            Mage::app()->getStore()
+                ->setId(Mage_Core_Model_App::ADMIN_STORE_ID)
+                ->setCode('admin');
+		
             Mage_Core_Model_Resource_Setup::applyAllUpdates();
             Mage_Core_Model_Resource_Setup::applyAllDataUpdates();
 

--- a/shell/upgrade.php
+++ b/shell/upgrade.php
@@ -65,12 +65,12 @@ class Guidance_Shell_Upgrade extends Mage_Shell_Abstract
         $start = microtime(true);
 
         try {
-		    //make upgrade scripts be executed from Admin store, not from default with ID = 1
-		    Mage::app()->setUpdateMode(true);
+            //make upgrade scripts be executed from Admin store, not from default with ID = 1
+            Mage::app()->setUpdateMode(true);
             Mage::app()->getStore()
                 ->setId(Mage_Core_Model_App::ADMIN_STORE_ID)
                 ->setCode('admin');
-		
+
             Mage_Core_Model_Resource_Setup::applyAllUpdates();
             Mage_Core_Model_Resource_Setup::applyAllDataUpdates();
 


### PR DESCRIPTION
Upgrade script should be run from Admin store to avoid many problems with upgrades in 3rd party modules or updating admin settings, CMS content, etc.